### PR TITLE
Use full path for inputs.

### DIFF
--- a/R/sentencepiece.R
+++ b/R/sentencepiece.R
@@ -60,6 +60,7 @@
 sentencepiece <- function(x, type = c("bpe", "char", "unigram", "word"), vocab_size = 8000, coverage = 0.9999, 
                           model_prefix = "sentencepiece", 
                           model_dir = tempdir(), threads = 1L, args, verbose = FALSE){
+  x <- normalizePath(x)
   oldwd <- getwd()
   on.exit(setwd(oldwd))
   setwd(model_dir)


### PR DESCRIPTION
Currently if we specify `model_dir` the input `x` will need to be relative to that path, which could be counter intuitive.
The scenario is that we put the training files in a data directory while we want the resulting model in another dedicated model directory.
By expanding `x` to its full path at the very beginning of the function call we shall be able to avoid any ambiguity resolving the path of both data and model directories.
